### PR TITLE
Build encryptor from arguments

### DIFF
--- a/lib/active_record_encryption/serializer_with_cast.rb
+++ b/lib/active_record_encryption/serializer_with_cast.rb
@@ -28,9 +28,11 @@ module ActiveRecordEncryption
     end
 
     # Backport Rails5.2
-    refine ActiveModel::Type::DateTime do
-      def serialize(value)
-        super(cast(value))
+    if ActiveRecord.gem_version < Gem::Version.create('5.2')
+      refine ActiveModel::Type::DateTime do
+        def serialize(value)
+          super(cast(value))
+        end
       end
     end
   end

--- a/lib/active_record_encryption/type.rb
+++ b/lib/active_record_encryption/type.rb
@@ -8,7 +8,7 @@ module ActiveRecordEncryption
     delegate :user_input_in_time_zone, to: :subtype # for ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
 
     def initialize(
-      subtype: ActiveRecord::Type.default_value,
+      subtype: default_value,
       encryption: ActiveRecordEncryption.default_encryption.clone,
       **options
     )
@@ -39,6 +39,15 @@ module ActiveRecordEncryption
     private
 
     attr_reader :subtype, :binary, :encryptor
+
+    # NOTE: `ActiveRecord::Type.default_value` is not defined in Rails 5.0
+    def default_value
+      if ActiveRecord.gem_version < Gem::Version.create('5.1.0')
+        ActiveRecord::Type::Value.new
+      else
+        ActiveRecord::Type.default_value
+      end
+    end
 
     def build_encryptor(options)
       encryptor = options.delete(:encryptor)

--- a/spec/active_record_encryption/type_spec.rb
+++ b/spec/active_record_encryption/type_spec.rb
@@ -1,6 +1,45 @@
 # frozen_string_literal: true
 
 RSpec.describe ActiveRecordEncryption::Type do
+  describe '#initialize' do
+    context 'given no arguments' do
+      it 'builds from default options' do
+        instance = described_class.new
+        expect(instance.send(:encryptor)).to be_a(ActiveRecordEncryption::Encryptor::Raw)
+        expect(instance.send(:subtype)).to eq(ActiveRecord::Type.default_value)
+      end
+    end
+
+    context 'given symbol as subtype' do
+      it 'builds from default options' do
+        instance = described_class.new(subtype: :integer)
+        expect(instance.send(:subtype)).to eq(ActiveRecord::Type.lookup(:integer))
+      end
+    end
+
+    context 'given hash as encryption' do
+      it 'builds from default options' do
+        instance = described_class.new(encryption: { encryptor: :active_support, key: 'key', salt: 'salt' })
+        expect(instance.send(:encryptor)).to be_a(ActiveRecordEncryption::Encryptor::ActiveSupport)
+      end
+    end
+
+    context 'given class as encryption' do
+      it 'builds from default options' do
+        instance = described_class.new(encryption: { encryptor: ActiveRecordEncryption::Encryptor::ActiveSupport, key: 'key', salt: 'salt' })
+        expect(instance.send(:encryptor)).to be_a(ActiveRecordEncryption::Encryptor::ActiveSupport)
+      end
+    end
+
+    context 'given instance of class as encryption' do
+      it 'builds from default options' do
+        encryptor = ActiveRecordEncryption::Encryptor::ActiveSupport.new(key: 'key', salt: 'salt')
+        instance = described_class.new(encryption: { encryptor: encryptor })
+        expect(instance.send(:encryptor)).to eq(encryptor)
+      end
+    end
+  end
+
   describe '#type' do
     subject { instance.type }
     let(:instance) { described_class.new(subtype: :integer) }

--- a/spec/active_record_encryption/type_spec.rb
+++ b/spec/active_record_encryption/type_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ActiveRecordEncryption::Type do
       it 'builds from default options' do
         instance = described_class.new
         expect(instance.send(:encryptor)).to be_a(ActiveRecordEncryption::Encryptor::Raw)
-        expect(instance.send(:subtype)).to eq(ActiveRecord::Type.default_value)
+        expect(instance.send(:subtype)).to eq(ActiveRecord::Type::Value.new)
       end
     end
 


### PR DESCRIPTION
Extend `encryption: { encryptor: xxx }` options.

Allow encryptor name,  encryptor class and encryptor instance.

```
encrypted_attribute(:field, :subtype, encryption: { encryptor: :encryptor })
encrypted_attribute(:field, :subtype, encryption: { encryptor: Encryptor })
encrypted_attribute(:field, :subtype, encryption: { encryptor: Encryptor.new(key: '') })
```