### PR TITLE
Handle keyword arguments separately

### DIFF
--- a/lib/active_record_encryption/encrypted_attribute.rb
+++ b/lib/active_record_encryption/encrypted_attribute.rb
@@ -6,7 +6,7 @@ module ActiveRecordEncryption
 
     module ClassMethods
       def encrypted_attribute(name, subtype, **options)
-        attribute(name, :encryption, options.merge(subtype: subtype))
+        attribute(name, :encryption, **options.merge(subtype: subtype))
       end
     end
   end

--- a/lib/active_record_encryption/type.rb
+++ b/lib/active_record_encryption/type.rb
@@ -57,7 +57,7 @@ module ActiveRecordEncryption
       if encryptor.is_a?(Symbol)
         ActiveRecordEncryption::Encryptor.lookup(encryptor, **options)
       elsif encryptor.is_a?(Class)
-        encryptor.new(options)
+        encryptor.new(**options)
       else
         encryptor
       end


### PR DESCRIPTION
Hi, alpaca-tc.

I got this warning on ruby 2.7.x and want to remove it.
```
encrypted_attribute.rb:9: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

If this patch is no problem, could you please merge it?

Thanks.