### PR TITLE
add AES-128-ECB support

### DIFF
--- a/lib/active_record_encryption/encryptor.rb
+++ b/lib/active_record_encryption/encryptor.rb
@@ -4,6 +4,7 @@ require 'active_record_encryption/encryptor/registry'
 require 'active_record_encryption/encryptor/base'
 require 'active_record_encryption/encryptor/raw'
 require 'active_record_encryption/encryptor/active_support'
+require 'active_record_encryption/encryptor/aes_128_ecb'
 require 'active_record_encryption/encryptor/aes_256_cbc'
 
 module ActiveRecordEncryption
@@ -25,6 +26,7 @@ module ActiveRecordEncryption
 
     register(:raw, ActiveRecordEncryption::Encryptor::Raw)
     register(:active_support, ActiveRecordEncryption::Encryptor::ActiveSupport)
+    register(:aes_128_ecb, ActiveRecordEncryption::Encryptor::Aes128Ecb)
     register(:aes_256_cbc, ActiveRecordEncryption::Encryptor::Aes256Cbc)
   end
 end

--- a/lib/active_record_encryption/encryptor/aes_128_ecb.rb
+++ b/lib/active_record_encryption/encryptor/aes_128_ecb.rb
@@ -11,6 +11,7 @@ module ActiveRecordEncryption
       end
 
       def encrypt(value)
+        return nil if value.nil?
         string = super.dup.force_encoding(encoding)
         encrypted_data = _encrypt(string, key)
 
@@ -20,6 +21,7 @@ module ActiveRecordEncryption
       end
 
       def decrypt(value)
+        return nil if value.nil?
         binary         = Binary.new(value)
         encrypted_data = binary.read
 

--- a/lib/active_record_encryption/encryptor/aes_128_ecb.rb
+++ b/lib/active_record_encryption/encryptor/aes_128_ecb.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'openssl'
+
+module ActiveRecordEncryption
+  module Encryptor
+    class ActiveRecordEncryption::Encryptor::Aes128Ecb < Raw
+      def initialize(key:, encoding: Encoding::UTF_8)
+        @key = key
+        @encoding = encoding
+      end
+
+      def encrypt(value)
+        string = super.dup.force_encoding(encoding)
+        encrypted_data = _encrypt(string, key)
+
+        binary = Binary.new
+        binary.write(encrypted_data)
+        binary.string
+      end
+
+      def decrypt(value)
+        binary         = Binary.new(value)
+        encrypted_data = binary.read
+
+        decrypted = _decrypt(encrypted_data, key)
+        decrypted.force_encoding(encoding)
+      end
+
+      def ==(other)
+        super &&
+          key == other.key &&
+          encoding == other.encoding
+      end
+
+      protected
+
+      attr_reader :key, :encoding
+
+      private
+
+      def valid_encoding?(value)
+        value.valid_encoding? && value.encoding == encoding
+      end
+
+      def _encrypt(value, key)
+        raise ArgumentError, "invalid string given. #{value}" unless valid_encoding?(value)
+
+        cipher = OpenSSL::Cipher.new('AES-128-ECB')
+        cipher.encrypt
+        cipher.key = key
+
+        result = ''.dup.tap do |buffer|
+          buffer << cipher.update(value) unless value.empty?
+          buffer << cipher.final
+        end
+
+        result
+      end
+
+      def _decrypt(value, key)
+        cipher = OpenSSL::Cipher.new('AES-128-ECB')
+        cipher.decrypt
+        cipher.key = key
+
+        ''.dup.tap do |buffer|
+          buffer << cipher.update(value)
+          buffer << cipher.final
+        end
+      end
+    end
+  end
+end

--- a/spec/active_record_encryption/encryptor/aes_128_ecb_spec.rb
+++ b/spec/active_record_encryption/encryptor/aes_128_ecb_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+RSpec.describe ActiveRecordEncryption::Encryptor::Aes128Ecb do
+  describe 'InstanceMethods' do
+    describe '#encrypt/decrypt' do
+      def build_instance(**options)
+        key = SecureRandom.random_bytes(16)
+        described_class.new(key: key, **options)
+      end
+
+      let(:value) { 'hello world' }
+
+      context 'with :encoding options' do
+        it 'encodes result' do
+          instance = build_instance(encoding: Encoding::BINARY)
+          encrypted = instance.encrypt(value)
+          decrypted = instance.decrypt(encrypted)
+
+          expect(decrypted.encoding).to eq(Encoding::BINARY)
+        end
+      end
+
+      context 'when key is same' do
+        it 'encrypts/decrypts value' do
+          instance = build_instance
+          encrypted = instance.encrypt(value)
+
+          expect(encrypted).to_not eq(value)
+
+          decrypted = instance.decrypt(encrypted)
+          expect(decrypted).to eq(value)
+        end
+
+        it 'generates same result' do
+          instance = build_instance
+
+          encrypted_1 = instance.encrypt(value)
+          encrypted_2 = instance.encrypt(value)
+
+          expect(encrypted_1).to eq(encrypted_2)
+        end
+      end
+
+      context 'when key is changed' do
+        it "doesn't decrypt value" do
+          instance_1 = build_instance
+          instance_2 = build_instance
+
+          encrypted = instance_1.encrypt(value)
+
+          expect { instance_2.decrypt(encrypted) }.to raise_error(OpenSSL::Cipher::CipherError)
+        end
+      end
+    end
+  end
+end

--- a/spec/active_record_encryption/encryptor/aes_128_ecb_spec.rb
+++ b/spec/active_record_encryption/encryptor/aes_128_ecb_spec.rb
@@ -51,6 +51,32 @@ RSpec.describe ActiveRecordEncryption::Encryptor::Aes128Ecb do
           expect { instance_2.decrypt(encrypted) }.to raise_error(OpenSSL::Cipher::CipherError)
         end
       end
+
+      context 'when value is nil' do
+        let(:value) { nil }
+        it 'encrypts/decrypts value' do
+          instance = build_instance
+          encrypted = instance.encrypt(value)
+
+          expect(encrypted).to be nil
+
+          decrypted = instance.decrypt(encrypted)
+          expect(decrypted).to eq(value)
+        end
+      end
+
+      context 'when value is blank string' do
+        let(:value) { '' }
+        it 'encrypts/decrypts value' do
+          instance = build_instance
+          encrypted = instance.encrypt(value)
+
+          expect(encrypted).to_not eq(value)
+
+          decrypted = instance.decrypt(encrypted)
+          expect(decrypted).to eq(value)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Hi,

I wanted to use AES- 128-ECB as encryption algorithm. Ah yes, I know it is not recommended algorithm at all, but it is default encryption algorithm on MySQL 5.7 and AWS aurora MySQL does not allow block_encryption_mode parameter. So I had to do it.