### PR TITLE
Migrate travis.ci to GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: Ruby
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['3.1']
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run rubocop
+      run: bundle exec rubocop
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        gemfile: ['6.1_stable', '7.0_stable']
+        ruby-version: ['3.0', '3.1']
+    services:
+      mysql:
+        image: mysql:5.7
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_ROOT_PASSWORD: password
+        options: --health-cmd "mysqladmin ping -h localhost" --health-interval 20s --health-timeout 10s --health-retries 10
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
+      ACTIVERECORD_ENCRYPTION_PASSWORD: 'password'
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run tests
+      run: bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   - Requires Ruby 3.0.0 or newer.
   - Requires Rails 6.1.0 or newer.
 - Support rails 7.0.0 #25
+- Migrate CI from travis.ci to GitHub Action. #27
+  - In Rails 7.0, `ActiveRecordEncryption` do not change encoding for backward compatibility.
 
 ## 0.3.0
 

--- a/lib/active_record_encryption.rb
+++ b/lib/active_record_encryption.rb
@@ -13,6 +13,7 @@ end
 
 ActiveSupport.on_load(:active_record) do
   require 'active_record_encryption/type'
+  require 'active_record_encryption/type/binary'
   require 'active_record_encryption/encryptor'
   require 'active_record_encryption/encrypted_attribute'
   require 'active_record_encryption/binary'
@@ -20,6 +21,7 @@ ActiveSupport.on_load(:active_record) do
 
   # Register `:encryption` type
   ActiveRecord::Type.register(:encryption, ActiveRecordEncryption::Type)
+  ActiveRecord::Type.register(:encryption_binary, ActiveRecordEncryption::Type::Binary)
 
   # Define `.encrypted_attribute`
   ActiveRecord::Base.include(ActiveRecordEncryption::EncryptedAttribute)

--- a/lib/active_record_encryption/type.rb
+++ b/lib/active_record_encryption/type.rb
@@ -10,10 +10,9 @@ module ActiveRecordEncryption
       encryption: ActiveRecordEncryption.default_encryption.clone,
       **options
     )
-
       # Lookup encryptor from options[:encryption]
       @encryptor = build_encryptor(encryption)
-      @binary = ActiveRecord::Type.lookup(:binary)
+      @binary = ActiveRecord::Type.lookup(:encryption_binary)
 
       subtype = ActiveRecord::Type.lookup(subtype, **options) if subtype.is_a?(Symbol)
       @subtype = subtype

--- a/lib/active_record_encryption/type/binary.rb
+++ b/lib/active_record_encryption/type/binary.rb
@@ -1,0 +1,17 @@
+module ActiveRecordEncryption
+  class Type
+    class Binary < ActiveModel::Type::Binary
+      def serialize(value)
+        return if value.nil?
+        Data.new(value)
+      end
+
+      class Data < ActiveModel::Type::Binary::Data
+        # NOTE: Don't convert string to binary for backward compatibility.
+        def initialize(value)
+          @value = value.to_s
+        end
+      end
+    end
+  end
+end

--- a/spec/support/activerecord.rb
+++ b/spec/support/activerecord.rb
@@ -18,8 +18,10 @@ class Mysql2Adapter < ActiveRecord::Base
     database: ENV.fetch('ACTIVERECORD_ENCRYPTION_DBNAME', 'active_record_encryption'),
     username: ENV.fetch('ACTIVERECORD_ENCRYPTION_USERNAME', 'root'),
     password: ENV.fetch('ACTIVERECORD_ENCRYPTION_PASSWORD', ''),
-    host: ENV.fetch('ACTIVERECORD_ENCRYPTION_HOST', '127.0.0.1')
+    host: ENV.fetch('ACTIVERECORD_ENCRYPTION_HOST', '127.0.0.1'),
   }.freeze
+
+  establish_connection(CONFIGURATION)
 
   def self.recreate_database
     establish_connection(configuration_without_database)


### PR DESCRIPTION
- Changed CI from travis to Github Action.
- Fixed Rails 7.0 was not working. In `ActiveModel::Type::Binary#serialize`, the string Encoding was changed to `Encoding::BINARY`. In `ActiveRecordEncryption`, fixed to not change Encoding for backward compatibility.